### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 # FAV Verifier
 </div>
+[![Run on Repl.it](https://repl.it/badge/github/favianrizqulloh/FAV-verifier)](https://repl.it/github/favianrizqulloh/FAV-verifier)
+
 A simple verification script used in the FΛV Community Discord Server | Made with discord.js
 
 1. Run `npm install`  


### PR DESCRIPTION
add a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment.